### PR TITLE
Consider enabling `htest` output from DCdensity.

### DIFF
--- a/DCdensity.R
+++ b/DCdensity.R
@@ -9,6 +9,7 @@
 #' @param verbose logical flag specifying whether to print diagnostic information to the terminal. (defaults to \code{FALSE})
 #' @param plot logical flag indicating whether to plot the histogram and density estimations (defaults to \code{TRUE}). The user may wrap this function in additional graphical options to modify the plot.
 #' @param ext.out logical flag indicating whether to return extended output. When \code{FALSE} (the default) \code{DCdensity} will return only the p-value of the test. When \code{TRUE}, \code{DCdensity} will return the additional information documented below.
+#' @param htest logical flag indicating whether to return an \code{"htest"} object compatible with base R's hypothesis test output.
 #' @return If \code{ext.out} is \code{FALSE}, only the p value will be returned. Additional output is enabled when \code{ext.out} is \code{TRUE}. In this case, a list will be returned with the following elements:
 #' \item{theta}{the estimated log difference in heights at the cutpoint}
 #' \item{se}{the standard error of \code{theta}}
@@ -32,7 +33,7 @@
 #' x<-x+2*(runif(1000,-1,1)>0&x<0)
 #' DCdensity(x,0)
 
-DCdensity <- function(runvar,cutpoint,bin=NULL,bw=NULL,verbose=FALSE,plot=TRUE,ext.out=FALSE) {
+DCdensity <- function(runvar,cutpoint,bin=NULL,bw=NULL,verbose=FALSE,plot=TRUE,ext.out=FALSE,htest=FALSE) {
   runvar <- runvar[complete.cases(runvar)]
   #Grab some summary vars
   rn <- length(runvar)
@@ -225,5 +226,17 @@ DCdensity <- function(runvar,cutpoint,bin=NULL,bw=NULL,verbose=FALSE,plot=TRUE,e
                 data=data.frame(cellmp,cellval)
                )
           )
-  return(p)
+  else if (htest) {
+      # Return an htest object, for compatibility with base R test output.
+      structure(list(
+          statistic   = c(`z` = z),
+          p.value     = p,
+          method      = "McCrary (2008) sorting test",
+          parameter   = c(`binwidth`  = bin,
+                          `bandwidth` = bw,
+                          `cutpoint`  = cutpoint),
+          alternative = "no apparent sorting"),
+          class = "htest")
+  }
+  else return(p)
 }


### PR DESCRIPTION
I'm not sure if you're accepting patches here, but I've been using the package lately and I thought it might be nice to have hypothesis test-style output from `DCdensity`.

This patch adds a flag to produce this output. So, for example using the [Jacob et al (2012)](http://www.mdrc.org/publication/practical-guide-regression-discontinuity) data:

``` r
> DCdensity(data$pretest, cutpoint = 215, bin = 3, bw = 12.04, plot = F, htest = T)
```

```
    McCrary (2008) sorting test

data:  
z = 0.7322, binwidth = 3.00, bandwidth = 12.04, cutpoint = 215.00, p-value = 0.464
alternative hypothesis: no apparent sorting
```

This also brings the test in line with many base R functions and packages.

I don't have a way of fully building the package to test it --- the DESCRIPTION file doesn't seem to be included in the git repo --- but I'm fairly confident it _will_ build.
